### PR TITLE
feat: add persistent polling interval with localStorage and DEFAULT_POLL_INTERVAL env var

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -159,6 +159,12 @@ _No open bugs._
 - **Backward compatibility** confirmed — legacy `GLUETUN_CONTROL_URL` env var still triggers single-instance mode when no numbered variables are detected.
 - **Code Review**: Comprehensive full-stack review completed. Overall assessment: **8-9/10 across all areas**. No critical security issues discovered. All existing open findings (S-03, S-05–S-08, C-01–C-06, D-01) confirmed unchanged.
 
+### Issue #17 fixed: Polling interval persistence
+
+- Added `localStorage` persistence for the polling interval selector. The selected interval (Off/5s/10s/30s/60s) is saved and restored on page load, so the user's preference persists across reloads.
+- Changed the change listener to save the selected value before reapplying the timeout.
+- Added constant `STORAGE_INTERVAL_KEY` for the storage key.
+
 ---
 
 ## Recent Updates (2026-02-25 — pass 2)

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -165,6 +165,11 @@ _No open bugs._
 - Changed the change listener to save the selected value before reapplying the timeout.
 - Added constant `STORAGE_INTERVAL_KEY` for the storage key.
 
+### Environment variable for default polling interval
+- Added `DEFAULT_POLL_INTERVAL` environment variable to set a default polling interval (in milliseconds) when no saved value is found in localStorage.
+- The value must be one of: 0 (off), 5000, 10000, 30000, 60000.
+- The server injects this value into the index.html meta tag `<meta id="default-poll-interval">` which the frontend reads on startup.
+
 ---
 
 ## Recent Updates (2026-02-25 — pass 2)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Each instance can have different authentication:
 | `GLUETUN_API_KEY` | _(empty)_ | **Legacy** – Bearer token for single instance |
 | `GLUETUN_USER` | _(empty)_ | **Legacy** – Username for HTTP Basic auth |
 | `GLUETUN_PASSWORD` | _(empty)_ | **Legacy** – Password for HTTP Basic auth |
+| `DEFAULT_POLL_INTERVAL` | _(empty)_ | Default polling interval in milliseconds (e.g., 10000 for 10s). If set, used when no saved preference exists in localStorage. Must be one of: 0, 5000, 10000, 30000, 60000. |
 | `PORT` | `3000` | Port the web UI listens on |
 | `TRUST_PROXY` | `false` | Set to `true` if running behind a reverse proxy (nginx, Traefik, etc.) |
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A lightweight web UI for monitoring and controlling [Gluetun](https://github.com
 - Auto-refresh with configurable interval (5s – 60s)
 - Last 30 poll ticks colour-coded in history bar
 - Responsive design (mobile, tablet, desktop)
+- Persistent polling interval selection (via localStorage)
 
 ---
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,6 +17,8 @@ services:
       #- GLUETUN_API_KEY=yourtoken
       #- GLUETUN_USER=username
       #- GLUETUN_PASSWORD=password
+      # Default polling interval in milliseconds (0, 5000, 10000, 30000, 60000)
+      #- DEFAULT_POLL_INTERVAL=10000
       # Set to 'true' if behind a reverse proxy (nginx, Traefik, etc.)
       #- TRUST_PROXY=false
     

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -332,11 +332,26 @@ function saveInterval() {
 
 // Restore saved polling interval
 const savedInterval = localStorage.getItem(STORAGE_INTERVAL_KEY);
+let intervalValue = null;
 if (savedInterval !== null) {
     const parsed = parseInt(savedInterval, 10);
     if (!isNaN(parsed) && [0, 5000, 10000, 30000, 60000].includes(parsed)) {
-        $('refresh-interval').value = parsed;
+        intervalValue = parsed;
     }
+}
+// If no valid saved value, try the meta tag for default from environment
+if (intervalValue === null) {
+    const meta = document.getElementById('default-poll-interval');
+    if (meta && meta.content) {
+        const metaValue = parseInt(meta.content, 10);
+        if (!isNaN(metaValue) && [0, 5000, 10000, 30000, 60000].includes(metaValue)) {
+            intervalValue = metaValue;
+        }
+    }
+}
+// Apply the value if found
+if (intervalValue !== null) {
+    $('refresh-interval').value = intervalValue;
 }
 
 $('refresh-btn').addEventListener('click', () => {

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2,6 +2,7 @@
 
 const MAX_HISTORY = 30;
 const VALID_STATES = new Set(['connected', 'paused', 'disconnected', 'unknown']);
+const STORAGE_INTERVAL_KEY = 'gluetun-poll-interval';
 
 let instances    = [];   // [{ id, name }] from /api/instances
 let isPolling    = false;
@@ -321,21 +322,41 @@ function applyAutoRefresh() {
 
 // ---- Init ----
 
+function saveInterval() {
+    const select = $('refresh-interval');
+    const value = parseInt(select.value, 10);
+    if (!isNaN(value)) {
+        localStorage.setItem(STORAGE_INTERVAL_KEY, value);
+    }
+}
+
+// Restore saved polling interval
+const savedInterval = localStorage.getItem(STORAGE_INTERVAL_KEY);
+if (savedInterval !== null) {
+    const parsed = parseInt(savedInterval, 10);
+    if (!isNaN(parsed) && [0, 5000, 10000, 30000, 60000].includes(parsed)) {
+        $('refresh-interval').value = parsed;
+    }
+}
+
 $('refresh-btn').addEventListener('click', () => {
-  clearTimeout(refreshTimer);
-  pollAll().then(() => scheduleNextPoll());
+    clearTimeout(refreshTimer);
+    pollAll().then(() => scheduleNextPoll());
 });
-$('refresh-interval').addEventListener('change', applyAutoRefresh);
+$('refresh-interval').addEventListener('change', () => {
+    saveInterval();
+    applyAutoRefresh();
+});
 
 (async () => {
-  try {
-    const res = await fetch('/api/instances');
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    instances = await res.json();
-  } catch (_) {
-    instances = [{ id: '1', name: 'Gluetun' }];
-  }
-  renderAllDashboards();
-  await pollAll();
-  scheduleNextPoll();
+    try {
+        const res = await fetch('/api/instances');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        instances = await res.json();
+    } catch (_) {
+        instances = [{ id: '1', name: 'Gluetun' }];
+    }
+    renderAllDashboards();
+    await pollAll();
+    scheduleNextPoll();
 })();

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta id="default-poll-interval" content="{{DEFAULT_POLL_INTERVAL}}" />
   <title>Gluetun-WebUI</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />

--- a/src/server.js
+++ b/src/server.js
@@ -310,7 +310,11 @@ app.put('/api/vpn/:action', vpnActionLimiter, async (req, res) => {
 app.use('/api/', (req, res) => res.status(404).json({ ok: false, error: 'Not found' }));
 
 app.get('*', staticLimiter, (req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+  const filePath = path.join(__dirname, 'public', 'index.html');
+  let html = fs.readFileSync(filePath, 'utf8');
+  const defaultInterval = process.env.DEFAULT_POLL_INTERVAL || '';
+  html = html.replace('{{DEFAULT_POLL_INTERVAL}}', defaultInterval);
+  res.send(html);
 });
 
 // Global error handler – catches synchronous throws and next(err) calls

--- a/src/server.js
+++ b/src/server.js
@@ -119,7 +119,9 @@ app.use((req, res, next) => {
 });
 
 app.use(express.json({ limit: '2kb' }));
-app.use(uiLimiter, express.static(path.join(__dirname, 'public')));
+app.use(uiLimiter, express.static(path.join(__dirname, 'public'), {
+  index: false,
+}));
 
 async function gluetunFetch(instance, endpoint, method = 'GET', body = null) {
   const url = `${instance.url}${endpoint}`;


### PR DESCRIPTION
**feat: add persistent polling interval with localStorage and DEFAULT_POLL_INTERVAL env var**

### What
- Saves user's selected poll interval to `localStorage` — persists across page reloads
- New env var `DEFAULT_POLL_INTERVAL` sets the server-side default (falls back to dropdown's first option)
- Valid values: `0` (disabled), `5000`, `10000`, `30000`, `60000` ms
- Works in conjunction with existing `GLUETUN_CONTROL_URL` / per-instance config

### Why
- Users often want a slower refresh rate to reduce load on Gluetun; previously every page visit reset to default
- Server operator can now enforce a sensible default via env var, while still letting users override per-browser

### How
- `app.js`: reads `gluetun-poll-interval` from localStorage on init; falls back to `<meta id="default-poll-interval">` injected by server; saves on dropdown change
- `server.js`: reads `DEFAULT_POLL_INTERVAL` from env, injects into HTML meta tag at serve time; also added `index: false` to `express.static()` to enable template injection
- `docker-compose.example.yml`: documented new env var

### Testing
- Tested locally in Docker with `DEFAULT_POLL_INTERVAL=5000` — meta tag injected correctly
- localStorage persistence verified in browser (Safari Web Inspector)
- Falls back to env var value after clearing localStorage

### Related
- Closes #17
