### PR TITLE
feat: server selection dropdown with AirVPN support

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -197,3 +197,14 @@ _No open bugs._
 - **D-02 (NEW)**: docker-compose.example.yml has a network key mismatch — the service references the Docker network name instead of the Compose key, silently creating the wrong network.
 - **D-03 / D-04 (Regressions)**: F-03 (`npm ci`) and F-12 (image digest pinning) were previously marked fixed but have regressed. `package-lock.json` was never committed, and the Dockerfile still uses a mutable tag.
 - All previously open findings (S-01 through S-08, C-01 through C-06, D-01) confirmed still present.
+
+### Issue #18 fixed: Ability to change VPN server
+
+- Added a "Change" button next to the server display in the VPN details card for each instance.
+- Clicking the button prompts the user to enter a new server hostname or IP address.
+- The new server is sent to the Gluetun instance via the `/api/:instanceId/settings` endpoint (PUT), updating the `ServerSelection.Hostnames` field to the new hostname and clearing the `Names` field.
+- The change takes effect after the VPN reconnects (visible on the next health poll).
+- This feature works for both single-instance and multi-instance configurations.
+- Note: The user must know the hostname or IP address of the desired server. To change server by country, city, etc., users can modify the corresponding settings via the `/api/:instanceId/settings` endpoint (not yet exposed in the UI).
+
+---

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A lightweight web UI for monitoring and controlling [Gluetun](https://github.com
 - Auto-refresh with configurable interval (5s – 60s)
 - Last 30 poll ticks colour-coded in history bar
 - Responsive design (mobile, tablet, desktop)
+- Ability to change VPN server (hostname/IP) via UI
+- Persistent polling interval selection (via localStorage)
 
 ---
 

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -6,6 +6,7 @@ const VALID_STATES = new Set(['connected', 'paused', 'disconnected', 'unknown'])
 let instances    = [];   // [{ id, name }] from /api/instances
 let isPolling    = false;
 let refreshTimer = null;
+const instanceSettings = new Map(); // id -> settings object (from /api/:instanceId/health vpnSettings.data)
 
 // ---- Utility ----
 
@@ -94,21 +95,21 @@ function buildDashboardGroup(inst) {
         </div>
       </div>
 
-      <!-- VPN details card -->
-      <div class="card">
-        <div class="card-header">
-          <span class="card-icon">&#128274;</span>
-          <h3>VPN Connection</h3>
-        </div>
-        <div class="card-body">
-          <div class="stat-row"><span class="stat-label">Status</span><span class="stat-value" id="i${id}-vpn-status">–</span></div>
-          <div class="stat-row"><span class="stat-label">Provider</span><span class="stat-value" id="i${id}-vpn-provider">–</span></div>
-          <div class="stat-row"><span class="stat-label">Server</span><span class="stat-value mono" id="i${id}-vpn-server">–</span></div>
-          <div class="stat-row"><span class="stat-label">Protocol</span><span class="stat-value" id="i${id}-vpn-protocol">–</span></div>
-          <div class="stat-row"><span class="stat-label">Country</span><span class="stat-value" id="i${id}-vpn-country">–</span></div>
-          <div class="stat-row"><span class="stat-label">City</span><span class="stat-value" id="i${id}-vpn-city">–</span></div>
-        </div>
-      </div>
+<!-- VPN details card -->
+       <div class="card">
+         <div class="card-header">
+           <span class="card-icon">&#128274;</span>
+           <h3>VPN Connection</h3>
+         </div>
+         <div class="card-body">
+           <div class="stat-row"><span class="stat-label">Status</span><span class="stat-value" id="i${id}-vpn-status">–</span></div>
+           <div class="stat-row"><span class="stat-label">Provider</span><span class="stat-value" id="i${id}-vpn-provider">–</span></div>
+           <div class="stat-row"><span class="stat-label">Server</span><div id="i${id}-server-container" class="server-input-container"><span class="stat-value mono" id="i${id}-vpn-server">–</span><button id="i${id}-change-server-btn" class="btn-small">Change</button></div></div>
+           <div class="stat-row"><span class="stat-label">Protocol</span><span class="stat-value" id="i${id}-vpn-protocol">–</span></div>
+           <div class="stat-row"><span class="stat-label">Country</span><span class="stat-value" id="i${id}-vpn-country">–</span></div>
+           <div class="stat-row"><span class="stat-label">City</span><span class="stat-value" id="i${id}-vpn-city">–</span></div>
+         </div>
+       </div>
 
       <!-- Port forwarding card -->
       <div class="card">
@@ -150,9 +151,18 @@ function buildDashboardGroup(inst) {
       </div>
     </div>
   `;
-  group.querySelector(`#i${id}-btn-start`).addEventListener('click', () => vpnAction(id, 'start'));
-  group.querySelector(`#i${id}-btn-stop`).addEventListener('click', () => vpnAction(id, 'stop'));
-  return group;
+group.querySelector(`#i${id}-btn-start`).addEventListener('click', () => vpnAction(id, 'start'));
+   group.querySelector(`#i${id}-btn-stop`).addEventListener('click', () => vpnAction(id, 'stop'));
+   const changeServerBtn = group.querySelector(`#i${id}-change-server-btn`);
+   changeServerBtn.addEventListener('click', () => {
+        const serverEl = group.querySelector(`#i${id}-vpn-server`);
+        const currentServer = serverEl.textContent.trim();
+        const newServer = prompt('Enter new server hostname or IP:', currentServer === '–' ? '' : currentServer);
+        if (newServer !== null && newServer.trim() !== '') {
+            updateServerForInstance(id, newServer.trim());
+        }
+   });
+   return group;
 }
 
 function renderAllDashboards() {
@@ -220,32 +230,88 @@ function updatePanel(inst, health) {
   const port = portForwarded?.ok ? (portForwarded.data?.port ?? 0) : 0;
   setEl(`i${id}-port-number`, port > 0 ? String(port) : portForwarded?.ok ? 'Not forwarded' : 'N/A');
 
-  setEl(`i${id}-dns-status`, dnsStatus?.ok ? (dnsStatus.data?.status ?? 'OK') : 'Unavailable');
+setEl(`i${id}-dns-status`, dnsStatus?.ok ? (dnsStatus.data?.status ?? 'OK') : 'Unavailable');
 
-  pushHistoryFor(id, state);
-  renderHistoryFor(id);
+   // Store the VPN settings for later use in server changes
+   if (s) {
+        instanceSettings.set(id, s);
+   } else {
+        instanceSettings.delete(id);
+   }
+
+   pushHistoryFor(id, state);
+   renderHistoryFor(id);
 }
 
 function updatePanelError(inst) {
-  const id = inst.id;
-  const banner = document.getElementById(`i${id}-banner`);
-  if (banner) banner.className = 'status-banner unknown';
-  setEl(`i${id}-banner-title`, 'Status Unknown');
-  setEl(`i${id}-banner-sub`, 'Could not reach Gluetun control API');
-  setEl(`i${id}-ip-address`, '–');
-  setEl(`i${id}-ip-country`, '–');
-  setEl(`i${id}-ip-city`, '–');
-  setEl(`i${id}-ip-org`, '–');
-  setEl(`i${id}-vpn-status`, '–');
-  setEl(`i${id}-vpn-provider`, '–');
-  setEl(`i${id}-vpn-server`, '–');
-  setEl(`i${id}-vpn-protocol`, '–');
-  setEl(`i${id}-vpn-country`, '–');
-  setEl(`i${id}-vpn-city`, '–');
-  setEl(`i${id}-port-number`, 'N/A');
-  setEl(`i${id}-dns-status`, 'Unavailable');
-  pushHistoryFor(id, 'unknown');
-  renderHistoryFor(id);
+   const id = inst.id;
+   const banner = document.getElementById(`i${id}-banner`);
+   if (banner) banner.className = 'status-banner unknown';
+   setEl(`i${id}-banner-title`, 'Status Unknown');
+   setEl(`i${id}-banner-sub`, 'Could not reach Gluetun control API');
+   setEl(`i${id}-ip-address`, '–');
+   setEl(`i${id}-ip-country`, '–');
+   setEl(`i${id}-ip-city`, '–');
+   setEl(`i${id}-ip-org`, '–');
+   setEl(`i${id}-vpn-status`, '–');
+   setEl(`i${id}-vpn-provider`, '–');
+   setEl(`i${id}-vpn-server`, '–');
+   setEl(`i${id}-vpn-protocol`, '–');
+   setEl(`i${id}-vpn-country`, '–');
+   setEl(`i${id}-vpn-city`, '–');
+   setEl(`i${id}-port-number`, 'N/A');
+   setEl(`i${id}-dns-status`, 'Unavailable');
+   pushHistoryFor(id, 'unknown');
+   renderHistoryFor(id);
+   // Remove stored settings for this instance on error to avoid stale data
+   instanceSettings.delete(id);
+}
+
+// Update server for a specific instance
+async function updateServerForInstance(instanceId, newServer) {
+   const settings = instanceSettings.get(instanceId);
+   if (!settings) {
+        showToast('Unable to retrieve settings for instance', 'error');
+        return;
+   }
+   const vpn = settings.VPN;
+   if (!vpn) {
+        showToast('VPN settings not found', 'error');
+        return;
+   }
+// Create a copy of the VPN object with updated server selection
+   const updatedVPN = {
+        ...vpn,
+        Provider: {
+            ...vpn.Provider,
+            ServerSelection: {
+                ...vpn.Provider.ServerSelection,
+                Method: 'manual',
+                ServerSelection: newServer
+            }
+        }
+   };
+   try {
+        const res = await fetch(`/api/${instanceId}/settings`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(updatedVPN)
+        });
+        if (!res.ok) {
+            const errorText = await res.text();
+            throw new Error(`HTTP ${res.status}: ${errorText}`);
+        }
+        showToast('Server updated successfully', 'success');
+        // Optionally, we can trigger a refresh to get the new server name from the settings
+        // But note: the server name in the UI comes from the health data, which will be updated on the next poll.
+        // We can also update the UI optimistically if we want.
+        // For now, we rely on the next poll to update the server display.
+   } catch (err) {
+        console.error('[updateServer]', err.message);
+        showToast(`Failed to update server: ${err.message}`, 'error');
+   }
 }
 
 // ---- API ----
@@ -327,7 +393,61 @@ $('refresh-btn').addEventListener('click', () => {
 });
 $('refresh-interval').addEventListener('change', applyAutoRefresh);
 
-(async () => {
+async function updateServerForInstance(instanceId, newServer) {
+    const settings = instanceSettings.get(instanceId);
+    if (!settings) {
+        showToast('Unable to retrieve settings for instance', 'error');
+        return;
+    }
+    // We have the full settings object.
+    // We need to update the ServerSelection inside settings.VPN.Provider
+    const vpn = settings.VPN;
+    if (!vpn) {
+        showToast('VPN settings not found', 'error');
+        return;
+    }
+    // Create a copy of the ServerSelection
+    const updatedServerSelection = {
+        ...vpn.Provider.ServerSelection,
+        Hostnames: [newServer],
+        Names: [] // clear the Names field to avoid conflict
+    };
+    // Update the Provider
+    const updatedProvider = {
+        ...vpn.Provider,
+        ServerSelection: updatedServerSelection
+    };
+    // Update the VPN
+    const updatedVpn = {
+        ...vpn,
+        Provider: updatedProvider
+    };
+    // Update the settings
+    const updatedSettings = {
+        ...settings,
+        VPN: updatedVpn
+    };
+    try {
+        const res = await fetch(`/api/${instanceId}/settings`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(updatedSettings)
+        });
+        if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`);
+        }
+        showToast(`Server updated for instance ${instanceId}`, 'success');
+        // Note: The server name in the UI might not update immediately until the VPN reconnects.
+        // It will be updated on the next health poll.
+    } catch (err) {
+        console.error(`[updateServer]`, err.message);
+        showToast(`Failed to update server: ${err.message}`, 'error');
+    }
+}
+
+   (async () => {
   try {
     const res = await fetch('/api/instances');
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -2,6 +2,7 @@
 
 const MAX_HISTORY = 30;
 const VALID_STATES = new Set(['connected', 'paused', 'disconnected', 'unknown']);
+const AIRVPN_SERVERS = ["Achernar", "Achird", "Adhara", "Adhil", "Agena", "Ainalrami", "Aladfar", "Alamak", "Albaldah", "Albali", "Alchiba", "Alcyone", "Alderamin", "Algorab", "Alhena", "Aljanah", "Alkurhah", "Alnitak", "Alphard", "Alphecca", "Alpheratz", "Alphirk", "Alrai", "Alrami", "Alruba", "Alsephina", "Alshat", "Alterf", "Aludra", "Alula", "Alwaid", "Alya", "Alzirr", "Amansinaya", "Ancha", "Andromeda", "Angetenar", "Anser", "Apus", "Aquila", "Arber", "Arkab", "Ascella", "Asellus", "Ashlesha", "Aspidiske", "Athebyne", "Atik", "Atria", "Auriga", "Avior", "Azelfafage", "Azmidiske", "Baiduri", "Baiten", "Beemim", "Benetnasch", "Bharani", "Biham", "Bubup", "Bunda", "Caelum", "Camelopardalis", "Canes", "Canis", "Capella", "Caph", "Capricornus", "Castor", "Castula", "Ceibo", "Celaeno", "Centaurus", "Cephei", "Cepheus", "Cervantes", "Chamaeleon", "Chamukuy", "Chaophraya", "Chara", "Chertan", "Chort", "Circinus", "Columba", "Comae", "Copernicus", "Crater", "Cujam", "Cygnus", "Dalim", "Delphinus", "Diadema", "Diphda", "Dorado", "Dubhe", "Dziban", "Edasich", "Elgafar", "Elkurud", "Elnath", "Eltanin", "Enif", "Equuleus", "Eridanus", "Errai", "Fang", "Fawaris", "Felis", "Fleed", "Fomalhaut", "Fulu", "Fuyue", "Garnet", "Gemini", "Gianfar", "Giausar", "Gienah", "Ginan", "Gorgonea", "Grus", "Guniibuu", "Hamal", "Hassaleh", "Helvetios", "Hercules", "Horologium", "Hyadum", "Hydra", "Hydrus", "Imai", "Iskandar", "Jabbah", "Jishui", "Kajam", "Khambalia", "Kocab", "Kornephoros", "Kruger", "Lacerta", "Larawag", "Leo", "Lesath", "Libra", "Luhman", "Lupus", "Luyten", "Maasym", "Maia", "Markab", "Marsic", "Matar", "Mebsuta", "Meissa", "Mekbuda", "Meleph", "Melnick", "Menkab", "Menkalinan", "Menkent", "Mensa", "Merga", "Meridiana", "Minchir", "Mintaka", "Mirach", "Miram", "Mirfak", "Mirzam", "Mothallah", "Muhlifain", "Muliphein", "Muphrid", "Musca", "Muscida", "Musica", "Nahn", "Nash", "Nembus", "Norma", "Ogma", "Okab", "Ophiuchus", "Orion", "Paikauhale", "Pegasus", "Phact", "Phaet", "Piautos", "Pisces", "Piscium", "Pleione", "Polis", "Praecipua", "Pyxis", "Ran", "Regulus", "Revati", "Ross", "Rotanev", "Rukbat", "Sadachbia", "Sadalbari", "Sadalmelik", "Sadalsuud", "Sadr", "Saiph", "Salm", "Sargas", "Sarin", "Schedir", "Sculptor", "Scuti", "Scutum", "Segin", "Sham", "Sharatan", "Sheliak", "Sheratan", "Sirrah", "Situla", "Sneden", "Sualocin", "Subra", "Suhail", "Sulafat", "Superba", "Taiyangshou", "Taiyi", "Talitha", "Taphao", "Tarazed", "Taurus", "Tegmen", "Tejat", "Telescopium", "Terebellum", "Theemin", "Tiaki", "Tianguan", "Tianyi", "Titawin", "Toliman", "Torcular", "Triangulum", "Turais", "Tyl", "Ukdah", "Unukalhai", "Unurgunite", "Ursa", "Vindemiatrix", "Volans", "Vulpecula", "Xamidimura", "Zibal"];
 
 let instances    = [];   // [{ id, name }] from /api/instances
 let isPolling    = false;
@@ -104,7 +105,7 @@ function buildDashboardGroup(inst) {
          <div class="card-body">
            <div class="stat-row"><span class="stat-label">Status</span><span class="stat-value" id="i${id}-vpn-status">–</span></div>
            <div class="stat-row"><span class="stat-label">Provider</span><span class="stat-value" id="i${id}-vpn-provider">–</span></div>
-           <div class="stat-row"><span class="stat-label">Server</span><div id="i${id}-server-container" class="server-input-container"><span class="stat-value mono" id="i${id}-vpn-server">–</span><button id="i${id}-change-server-btn" class="btn-small">Change</button></div></div>
+           <div class="stat-row"><span class="stat-label">Server</span><div id="i${id}-server-container" class="server-input-container"><select id="i${id}-server-select" class="server-select"><option value="">Auto (best)</option></select></div></div>
            <div class="stat-row"><span class="stat-label">Protocol</span><span class="stat-value" id="i${id}-vpn-protocol">–</span></div>
            <div class="stat-row"><span class="stat-label">Country</span><span class="stat-value" id="i${id}-vpn-country">–</span></div>
            <div class="stat-row"><span class="stat-label">City</span><span class="stat-value" id="i${id}-vpn-city">–</span></div>
@@ -153,15 +154,11 @@ function buildDashboardGroup(inst) {
   `;
 group.querySelector(`#i${id}-btn-start`).addEventListener('click', () => vpnAction(id, 'start'));
    group.querySelector(`#i${id}-btn-stop`).addEventListener('click', () => vpnAction(id, 'stop'));
-   const changeServerBtn = group.querySelector(`#i${id}-change-server-btn`);
-   changeServerBtn.addEventListener('click', () => {
-        const serverEl = group.querySelector(`#i${id}-vpn-server`);
-        const currentServer = serverEl.textContent.trim();
-        const newServer = prompt('Enter new server hostname or IP:', currentServer === '–' ? '' : currentServer);
-        if (newServer !== null && newServer.trim() !== '') {
-            updateServerForInstance(id, newServer.trim());
-        }
-   });
+    const serverSelect = group.querySelector(`#i${id}-server-select`);
+    serverSelect.addEventListener('change', () => {
+         const selected = serverSelect.value;
+         updateServerForInstance(id, selected);
+    });
    return group;
 }
 
@@ -234,9 +231,29 @@ setEl(`i${id}-dns-status`, dnsStatus?.ok ? (dnsStatus.data?.status ?? 'OK') : 'U
 
    // Store the VPN settings for later use in server changes
    if (s) {
-        instanceSettings.set(id, s);
+       instanceSettings.set(id, s);
+       const select = document.getElementById(`i${id}-server-select`);
+       if (select) {
+           const provider = s?.provider?.name ?? '';
+           if (provider === 'airvpn') {
+               if (select.options.length <= 1) {
+                   AIRVPN_SERVERS.forEach(name => {
+                       const opt = document.createElement('option');
+                       opt.value = name;
+                       opt.textContent = name;
+                       select.appendChild(opt);
+                   });
+               }
+               select.disabled = false;
+               const serverName = s?.provider?.server_selection?.names?.[0] ?? '';
+               select.value = serverName;
+           } else {
+               select.innerHTML = '<option value="">Auto (best)</option>';
+               select.disabled = true;
+           }
+       }
    } else {
-        instanceSettings.delete(id);
+       instanceSettings.delete(id);
    }
 
    pushHistoryFor(id, state);
@@ -265,53 +282,6 @@ function updatePanelError(inst) {
    renderHistoryFor(id);
    // Remove stored settings for this instance on error to avoid stale data
    instanceSettings.delete(id);
-}
-
-// Update server for a specific instance
-async function updateServerForInstance(instanceId, newServer) {
-   const settings = instanceSettings.get(instanceId);
-   if (!settings) {
-        showToast('Unable to retrieve settings for instance', 'error');
-        return;
-   }
-   const vpn = settings.VPN;
-   if (!vpn) {
-        showToast('VPN settings not found', 'error');
-        return;
-   }
-// Create a copy of the VPN object with updated server selection
-   const updatedVPN = {
-        ...vpn,
-        Provider: {
-            ...vpn.Provider,
-            ServerSelection: {
-                ...vpn.Provider.ServerSelection,
-                Method: 'manual',
-                ServerSelection: newServer
-            }
-        }
-   };
-   try {
-        const res = await fetch(`/api/${instanceId}/settings`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(updatedVPN)
-        });
-        if (!res.ok) {
-            const errorText = await res.text();
-            throw new Error(`HTTP ${res.status}: ${errorText}`);
-        }
-        showToast('Server updated successfully', 'success');
-        // Optionally, we can trigger a refresh to get the new server name from the settings
-        // But note: the server name in the UI comes from the health data, which will be updated on the next poll.
-        // We can also update the UI optimistically if we want.
-        // For now, we rely on the next poll to update the server display.
-   } catch (err) {
-        console.error('[updateServer]', err.message);
-        showToast(`Failed to update server: ${err.message}`, 'error');
-   }
 }
 
 // ---- API ----
@@ -394,56 +364,40 @@ $('refresh-btn').addEventListener('click', () => {
 $('refresh-interval').addEventListener('change', applyAutoRefresh);
 
 async function updateServerForInstance(instanceId, newServer) {
-    const settings = instanceSettings.get(instanceId);
-    if (!settings) {
-        showToast('Unable to retrieve settings for instance', 'error');
+    const s = instanceSettings.get(instanceId);
+    if (!s) {
+        showToast('Instance settings not loaded yet. Wait for first poll.', 'error');
         return;
     }
-    // We have the full settings object.
-    // We need to update the ServerSelection inside settings.VPN.Provider
-    const vpn = settings.VPN;
-    if (!vpn) {
-        showToast('VPN settings not found', 'error');
+    const prov = s?.provider;
+    if (!prov) {
+        showToast('Provider settings not found', 'error');
         return;
     }
-    // Create a copy of the ServerSelection
-    const updatedServerSelection = {
-        ...vpn.Provider.ServerSelection,
-        Hostnames: [newServer],
-        Names: [] // clear the Names field to avoid conflict
-    };
-    // Update the Provider
-    const updatedProvider = {
-        ...vpn.Provider,
-        ServerSelection: updatedServerSelection
-    };
-    // Update the VPN
-    const updatedVpn = {
-        ...vpn,
-        Provider: updatedProvider
-    };
-    // Update the settings
+    const ss = prov.server_selection;
     const updatedSettings = {
-        ...settings,
-        VPN: updatedVpn
+        ...s,
+        provider: {
+            ...prov,
+            server_selection: {
+                ...ss,
+                names: newServer ? [newServer] : null,
+                hostnames: null
+            }
+        }
     };
+    // ponytail: full settings object sent, Gluetun only picks what changed
     try {
         const res = await fetch(`/api/${instanceId}/settings`, {
             method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(updatedSettings)
         });
-        if (!res.ok) {
-            throw new Error(`HTTP ${res.status}`);
-        }
-        showToast(`Server updated for instance ${instanceId}`, 'success');
-        // Note: The server name in the UI might not update immediately until the VPN reconnects.
-        // It will be updated on the next health poll.
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        showToast(newServer ? `Switching to ${newServer}…` : 'Auto-selecting best server…', 'success');
     } catch (err) {
-        console.error(`[updateServer]`, err.message);
-        showToast(`Failed to update server: ${err.message}`, 'error');
+        console.error('[updateServer]', err.message);
+        showToast(`Failed: ${err.message}`, 'error');
     }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -118,13 +118,14 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use(express.json({ limit: '2kb' }));
+app.use(express.json({ limit: '2mb' }));
 app.use(uiLimiter, express.static(path.join(__dirname, 'public')));
 
 async function gluetunFetch(instance, endpoint, method = 'GET', body = null) {
   const url = `${instance.url}${endpoint}`;
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const ms = method === 'PUT' ? 60000 : 5000;
+  const timeoutId = setTimeout(() => controller.abort(), ms);
   const opts = {
     method,
     signal: controller.signal,
@@ -141,7 +142,8 @@ async function gluetunFetch(instance, endpoint, method = 'GET', body = null) {
       const text = await res.text().catch(() => '');
       throw new Error(`Gluetun returned ${res.status}${text ? ': ' + text.slice(0, 200).trim() : ''}`);
     }
-    return res.json();
+    const text = await res.text();
+    try { return JSON.parse(text); } catch { return text; }
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/server.js
+++ b/src/server.js
@@ -234,6 +234,35 @@ app.get('/api/settings', async (req, res) => {
   }
 });
 
+app.get('/api/:instanceId/settings', async (req, res) => {
+  const instance = resolveInstance(req.params.instanceId);
+  if (!instance) return res.status(400).json({ ok: false, error: 'Unknown instance ID' });
+  try {
+    const data = await gluetunFetch(instance, '/v1/vpn/settings');
+    res.json({ ok: true, data });
+  } catch (err) {
+    console.error('[upstream]', err.message);
+    res.status(502).json({ ok: false, error: 'Upstream error' });
+  }
+});
+
+app.put('/api/:instanceId/settings', async (req, res) => {
+  const instance = resolveInstance(req.params.instanceId);
+  if (!instance) return res.status(400).json({ ok: false, error: 'Unknown instance ID' });
+  try {
+    const data = await gluetunFetch(
+      instance,
+      '/v1/vpn/settings',
+      'PUT',
+      req.body
+    );
+    res.json({ ok: true, data });
+  } catch (err) {
+    console.error('[upstream]', err.message);
+    res.status(502).json({ ok: false, error: 'Upstream error' });
+  }
+});
+
 app.get('/api/dns', async (req, res) => {
   try {
     const data = await gluetunFetch(instances[0], '/v1/dns/status');

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,10 @@
+/* Server input container */
+.server-input-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.btn-small {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+}


### PR DESCRIPTION
Implements a dropdown populated from AirVPN server list. For non-AirVPN providers, dropdown stays as 'Auto (best)' disabled. Future versions could allow for selection of servers on other providers. I only use AirVPN and could only test with it for now, but would be nice to expand to others.