### PR TITLE
feat: theme picker — dark, light, and auto

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -319,6 +319,35 @@ function applyAutoRefresh() {
   scheduleNextPoll();
 }
 
+// ---- Theme ----
+
+const THEMES = ['dark', 'light', 'auto'];
+const THEME_ICONS = { dark: '&#9790;', light: '&#9728;', auto: '&#9681;' };
+let currentTheme = 'dark';
+
+function applyTheme(theme) {
+  currentTheme = theme;
+  if (theme === 'auto') {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+  } else {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+  const btn = $('theme-toggle');
+  if (btn) btn.innerHTML = THEME_ICONS[theme];
+}
+
+function cycleTheme() {
+  const idx = THEMES.indexOf(currentTheme);
+  const next = THEMES[(idx + 1) % THEMES.length];
+  localStorage.setItem('gluetun_theme', next);
+  applyTheme(next);
+}
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  if (currentTheme === 'auto') applyTheme('auto');
+});
+
 // ---- Init ----
 
 $('refresh-btn').addEventListener('click', () => {
@@ -326,6 +355,10 @@ $('refresh-btn').addEventListener('click', () => {
   pollAll().then(() => scheduleNextPoll());
 });
 $('refresh-interval').addEventListener('change', applyAutoRefresh);
+$('theme-toggle').addEventListener('click', cycleTheme);
+
+// Load saved theme
+applyTheme(localStorage.getItem('gluetun_theme') || 'dark');
 
 (async () => {
   try {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -21,6 +21,7 @@
       <div class="header-right">
         <span id="last-updated" class="muted">–</span>
         <button id="refresh-btn" title="Refresh now">&#x21bb; Refresh</button>
+        <button id="theme-toggle" title="Toggle theme">&#9789;</button>
         <label class="auto-refresh-label" title="Auto-refresh interval">
           <span>Auto</span>
           <select id="refresh-interval">

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -21,7 +21,6 @@
       <div class="header-right">
         <span id="last-updated" class="muted">–</span>
         <button id="refresh-btn" title="Refresh now">&#x21bb; Refresh</button>
-        <button id="theme-toggle" title="Toggle theme">&#9789;</button>
         <label class="auto-refresh-label" title="Auto-refresh interval">
           <span>Auto</span>
           <select id="refresh-interval">
@@ -32,6 +31,7 @@
             <option value="60000">60s</option>
           </select>
         </label>
+        <button id="theme-toggle" title="Toggle theme">&#9789;</button>
       </div>
     </div>
   </header>

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -15,6 +15,15 @@
   --radius: 12px;
   --shadow: 0 4px 24px rgba(0,0,0,0.4);
 }
+[data-theme="light"] {
+  --bg: #f1f5f9;
+  --surface: #ffffff;
+  --surface2: #f8fafc;
+  --border: #e2e8f0;
+  --text: #1e293b;
+  --muted: #94a3b8;
+  --shadow: 0 4px 24px rgba(0,0,0,0.08);
+}
 
 html { font-size: 15px; }
 body {
@@ -68,6 +77,7 @@ button {
   transition: background 0.15s, border-color 0.15s;
 }
 button:hover { background: var(--border); }
+#theme-toggle { font-size: 1.1rem; line-height: 1; width: 2.2rem; display: flex; align-items: center; justify-content: center; }
 
 .auto-refresh-label {
   display: flex;


### PR DESCRIPTION
Cycle through dark/light/auto modes via header button:
- **Dark** (☾) — current default
- **Light** (☀) — new clean light theme
- **Auto** (◐) — follows OS prefers-color-scheme

Preference persists to localStorage. Auto mode listens for OS theme changes in real time.